### PR TITLE
Fix: Update Gradle build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,30 @@ DerivedData
 *.xcuserstate
 project.xcworkspace
 
+
+# Node
+node_modules
+package-log.json
+*.log
+
+# Gradle
+/build/
+/RNTester/android/app/build/
+/RNTester/android/app/gradle/
+/RNTester/android/app/gradlew
+/RNTester/android/app/gradlew.bat
+/ReactAndroid/build/
+
+# Android/IntelliJ
+build/
+.idea
+.gradle
+local.properties
+*.iml
+*.hprof
+*.project
+
+
 # node.js
 #
 node_modules/

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,5 +16,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
This fork is using an outdated Gradle DSL method, such as compile(), which has been deprecated since Gradle 3.0 and removed in Gradle 7.x. The modern equivalent is implementation() or api(), depending on the situation.